### PR TITLE
Enviar como parâmetro o cabeçalho 'Content-Type' em comando da página…

### DIFF
--- a/pages/index_type_document.md
+++ b/pages/index_type_document.md
@@ -3,7 +3,7 @@
 Agora que fizemos a instalação e garantimos que o nosso Elasticsearch está operacional, vamos entender na prática o que é um _index_, _type_ e um _document_. Para isto, vamos começar a colocar alguns dados no nosso Elasticsearch ! Execute o comando abaixo:
 
 ```
-curl -XPUT http://localhost:9200/mycompany/funcionarios/1 -d '
+curl -XPUT http://localhost:9200/mycompany/funcionarios/1 -H 'Content-Type: application/json' -d '
 {
   "nome": "João Silva",
   "idade": 19,


### PR DESCRIPTION
… 'Index, Type, Document?'

Em alguns ambientes a ausência do cabeçalho 'Content-Type' em requisições realizadas com a ferramenta CURL pode retornar erro e abortar a execução do comando.